### PR TITLE
Update hyperhtml to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Andrea Giammarchi",
   "license": "ISC",
   "dependencies": {
-    "hyperhtml": "^2.22.0",
+    "hyperhtml": "^2.28.0",
     "viperhtml": "^2.17.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
What happened to the greenkeeper bot?

Current hyperhtml version: `v2.28.0`

package.json version: `^2.22.0`

Last greenkeeper Pull Request was on the 28.06.2018 with hyperhtml `v2.12.0`: #20